### PR TITLE
Upgrade Hadoop version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 object Dependencies {
 
   val projectDependencies = Seq(
-    "org.apache.hadoop" % "hadoop-client" % "2.7.3" excludeAll(
+    "org.apache.hadoop" % "hadoop-client" % "2.8.3" excludeAll(
       ExclusionRule("javax.servlet"),
       ExclusionRule("javax.servlet.jsp"),
       ExclusionRule("org.mortbay.jetty"),


### PR DESCRIPTION
The Hadoop version currently used by this project conflicts with the Hadoop version used by `spark-testing-base 2.1.2_0.10.0`, thus making tests in Spark 2.1.2 applications unreliable due to dependency resolution conflicts.

This PR upgrades the Hadoop version used by ghdfs in order to make it compatible with that versions of spark-testing-base.